### PR TITLE
Remove PL post install hook that was modifying files

### DIFF
--- a/patternlab/composer.json
+++ b/patternlab/composer.json
@@ -35,12 +35,9 @@
 	},
 	"scripts": {
 		"post-install-cmd": [
-			"PatternLab\\Installer::postInstallCmd",
-			"sudo echo '{\"patternengines\":[\"\\\\PatternLab\\\\PatternEngine\\\\Twig\\\\PatternEngineRule\"]}' >| config/patternengines.json",
-			"sudo echo '{\"listeners\":[\"\\\\PatternLab\\\\TwigNamespaces\\\\PatternLabListener\"]}' > config/listeners.json"
+			"PatternLab\\Installer::postInstallCmd"
 		],
 		"post-update-cmd": [
-			"PatternLab\\Installer::postUpdateCmd"
 		],
 		"post-root-package-install": [
 			"PatternLab\\Installer::setProjectInstall",


### PR DESCRIPTION
Simply remove the post install hook from composer so patternlab doesn't have a chance to break itself by editing it's own config. Fixes #11 and #10